### PR TITLE
Remove ga4gh connect 2026 hackathon project label from templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-proposal.yaml
+++ b/.github/ISSUE_TEMPLATE/project-proposal.yaml
@@ -1,7 +1,6 @@
 name: project proposal
-description: GKS Connect Hackathon 2026 Project Proposal
+description: Future Hackathon Project Proposal
 title: "[Project title]"
-labels: GA4GH-Connect-2026
 
 body:
   - type: input


### PR DESCRIPTION
Will be closing issues at 10 AM EST